### PR TITLE
Remove --frozen-lockfile from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ before_install:
   - export PATH="$HOME/.yarn/bin:$PATH"
   - yarn global add greenkeeper-lockfile@1
 
-install:
-  - yarn --frozen-lockfile
-
 before_script:
   - greenkeeper-lockfile-update
 


### PR DESCRIPTION
This was causing greenkeeper, which needs to update the lockfile, to fail all PRs.